### PR TITLE
Split PodMeta in several files and use json schemas

### DIFF
--- a/PodMeta-Metadata_Exchange/v1/Chapter.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Chapter.schema.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https://example.com/chapter.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Chapter",
+  "type": "object",
+  "description": "Chapter JSON Schema\n\nThis implemented a json schema from the podcastindex.org chapters proposal\n\nSee https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md",
+  "examples": [],
+  "properties": {
+    "starttime": {
+      "type": "number",
+      "description": "The starting time of the chapter, expressed in seconds with float precision for fractions of a second."
+    },
+    "title": {
+      "type": "string",
+      "description": "The title of this chapter."
+    },
+    "img": {
+      "type": "string",
+      "description": "The url of an image to use as chapter art."
+    },
+    "url": {
+      "type": "string",
+      "description": "The url of a web page or supporting document that's related to the topic of this chapter."
+    },
+    "toc": {
+      "type": "boolean",
+      "description": "If this property is present and set to false, this chapter should not display visibly to the user in either the table of contents or as a jump-to point in the user interface. It should be considered a \"silent\" chapter marker for the purpose of meta-data only. If this property is set to true or not present at all, this should be considered a normal chapter for display to the user. The name \"toc\" is short for \"table of contents\"."
+    },
+    "endtime": {
+      "type": "number",
+      "description": "The end time of the chapter, expressed in seconds with float precision for fractions of a second."
+    },
+    "location": {
+      "$ref": "/Location.schema",
+      "description": "This object defines an optional location that is tied to this chapter. It follows the structure of the location tag in the XML namespace."
+    }
+  },
+  "required": [
+    "starttime"
+  ]
+}

--- a/PodMeta-Metadata_Exchange/v1/Chapters.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Chapters.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://example.com/chapters.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Chapters",
+  "type": "object",
+  "description": "Chapters JSON Schema\n\nThis implemented a json schema from the podcastindex.org chapters proposal\n\nSee https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md",
+  "examples": [],
+  "properties": {
+    "version": {
+      "type": "string",
+      "default": "1.2.0",
+      "description": "The version number of the format being used"
+    },
+    "chapters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "": {
+            "$ref": "/Chapter.schema",
+            "description": "An array of chapter objects defined below"
+          }
+        }
+      }
+    },
+    "author": {
+      "type": "string",
+      "description": "The name of the author of this podcast episode."
+    },
+    "title": {
+      "type": "string",
+      "description": "The title of this podcast episode."
+    },
+    "podcastName": {
+      "type": "string",
+      "description": "The name of the podcast this episode belongs to."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of this episode."
+    },
+    "fileName": {
+      "type": "string",
+      "description": "The name of the audio file these chapters apply to."
+    },
+    "waypoints": {
+      "type": "boolean",
+      "description": "If this property is present, the locations in a chapter object should be displayed with a route between locations."
+    }
+  },
+  "required": [
+    "version"
+  ]
+}

--- a/PodMeta-Metadata_Exchange/v1/Contributor.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Contributor.schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://example.com/contributor.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Contributor",
+  "type": "object",
+  "description": "Contributor JSON Schema",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "website": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/PodMeta-Metadata_Exchange/v1/Episode.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Episode.schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "https://example.com/episode.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Episode",
+  "type": "object",
+  "description": "Episode JSON Schema",
+  "examples": [],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "number": {
+      "type": "string"
+    },
+    "season": {
+      "type": "string"
+    },
+    "release_date": {
+      "type": "string",
+      "description": "ISO 8061 (see https://de.wikipedia.org/wiki/ISO_8601)"
+    },
+    "language": {
+      "type": "string"
+    },
+    "explicit": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    },
+    "shownotes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "shownotes": {
+            "$ref": "/Shownote.schema"
+          }
+        }
+      }
+    },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "contributors": {
+            "$ref": "/Contributor.schema"
+          }
+        }
+      }
+    }
+  }
+}

--- a/PodMeta-Metadata_Exchange/v1/Location.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Location.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://example.com/location.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Location",
+  "type": "object",
+  "description": "Location JSON Schema\n\nThis implemented a json schema from the podcastindex.org location proposal\n\nSee https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md",
+  "examples": [],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "geo": {
+      "type": "string"
+    }
+  }
+}

--- a/PodMeta-Metadata_Exchange/v1/Podcast.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Podcast.schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://example.com/podcast.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Podcast",
+  "type": "object",
+  "description": "Podcast JSON Schema",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "mail": {
+      "type": "string"
+    },
+    "website": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/PodMeta-Metadata_Exchange/v1/SampleFiles/Episode.json
+++ b/PodMeta-Metadata_Exchange/v1/SampleFiles/Episode.json
@@ -1,0 +1,29 @@
+{
+    "title": "Ein Blick auf die Publisher Beta 4",
+    "subtitle": "Eine neue Version in den Startlöchern",
+    "summary": "Der Podlovers-Podcast meldet sich zurück. Alex, Dirk, Eric und Martin geben Euch einen Einblick in die Beta der neuen Version und stellen die wichtigsten Neuerungen vor. Hört rein und testet dann gerne mit.",
+    "number": "23",
+    "release_date": "20230730T18:22:17+02:00",
+    "language": "de",
+    "explicit": "no",
+    "contributors": [
+        {
+            "name": "Dirk",
+            "description": "Developer",
+            "role": "Host"
+        },
+        {
+            "name": "Eric",
+            "description": "Developer",
+            "role": "Host"
+        }
+    ],
+    "shownotes": [
+        {
+            "title": "Install Podlove Publisher Beta",
+            "description": "How to install the beta",
+            "timestamp": "00:04:23",
+            "url": "https://www.youtube.com/watch?v=lMHFyHPMn4Q"
+        }
+    ]
+}

--- a/PodMeta-Metadata_Exchange/v1/SampleFiles/Podcast.json
+++ b/PodMeta-Metadata_Exchange/v1/SampleFiles/Podcast.json
@@ -1,0 +1,18 @@
+{
+    "title": "Podlovers",
+    "subtitle": "",
+    "description": "Der Podlove Entwickler:innen Podcast",
+    "mail": "test@example.com",
+    "website" : [
+        {
+            "name" : "homepage",
+            "description" : "Homepage podlovers",
+            "url" : "https://podlovers,org"
+        },
+        {
+            "name" : "podlove",
+            "description": "Podlove Homepage",
+            "url" : "https://podlove.org"
+        }
+    ]
+}

--- a/PodMeta-Metadata_Exchange/v1/Shownote.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Shownote.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://example.com/shownote.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Shownote",
+  "type": "object",
+  "description": "Shownote JSON Schema",
+  "examples": [],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "location": {
+      "$ref": "/Location.schema"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "use NormalPlayTime (hh:mm:ss.ms)"
+    },
+    "url": {
+      "type": "string"
+    },
+    "is_advertisement": {
+      "type": "boolean"
+    },
+    "uuid": {
+      "type": "string"
+    }
+  }
+}

--- a/PodMeta-Metadata_Exchange/v1/Transcripts.schema.json
+++ b/PodMeta-Metadata_Exchange/v1/Transcripts.schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://example.com/transcripts.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Transcripts",
+  "type": "object",
+  "description": "Trascripts JSON Schema\n\nThis implemented a json schema from the podcastindex.org transcripts proposal\n\nSee https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md",
+  "examples": [],
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+    "segments": {
+      "type": "object",
+      "properties": {
+        "speaker": {
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string"
+        },
+        "endTime": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Dies ist ein Vorschlag die Daten aus der Strukur PodMeta aufzuspalten. Dies macht es einfacher die Daten zu erstellen und zu validieren. 

Die Schemas Chapter, Chapters, Location und Transcript entsprechen den Strukturen von podcastindex.org. 

 Die Strukturen Episode und Podcast sind aus meiner Sicht nur für den Austausch zwischen Podcast-Softwaresystemen interessant. Die Struktur Shownote wäre auch für den Podcast-Feed sinnvoll. Eventuell erstelle ich dafür ein Proposal bei podcastindex.org.
